### PR TITLE
Potential fix for code scanning alert no. 7: Log entries created from user input

### DIFF
--- a/func-cs02/Func_cs02.cs
+++ b/func-cs02/Func_cs02.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
@@ -20,7 +21,16 @@ namespace Func_cs02
         {
             foreach (var header in req.Headers)
             {
-                logger.LogInformation("{HeaderName}: {HeaderValue}", header.Key, header.Value.ToString());
+                var safeHeaderName = header.Key
+                    .Replace(Environment.NewLine, " ")
+                    .Replace("\r", " ")
+                    .Replace("\n", " ");
+                var safeHeaderValue = header.Value.ToString()
+                    .Replace(Environment.NewLine, " ")
+                    .Replace("\r", " ")
+                    .Replace("\n", " ");
+
+                logger.LogInformation("{HeaderName}: {HeaderValue}", safeHeaderName, safeHeaderValue);
             }
 
             return new OkObjectResult("This is responded by function [auth-cs] in func-cs02. It means HTTP triggered function executed successfully.");


### PR DESCRIPTION
Potential fix for [https://github.com/anishi1222/managed-identity-for-Azure-Functions-in-.NET/security/code-scanning/7](https://github.com/anishi1222/managed-identity-for-Azure-Functions-in-.NET/security/code-scanning/7)

To fix this, sanitize header names/values before logging by removing line break characters (and optionally other control characters if desired). This preserves functionality (still logs headers) while preventing log-entry injection/forgery via newline/control sequences.

Best minimal fix in `func-cs02/Func_cs02.cs`:
- Add `using System;` (for `Environment.NewLine`).
- In the `foreach` loop, compute sanitized `safeHeaderName` and `safeHeaderValue` by replacing `\r`, `\n`, and `Environment.NewLine` with safe separators/empty string.
- Log the sanitized variables instead of raw `header.Key` / `header.Value.ToString()`.

This keeps behavior intact and directly addresses the tainted sink on line 23.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
