### PR TITLE
Potential fix for code scanning alert no. 5: Log entries created from user input

### DIFF
--- a/func-cs01/Func_cs01.cs
+++ b/func-cs01/Func_cs01.cs
@@ -53,7 +53,8 @@ namespace Func_cs01
                 logger.LogError("Query Parameter is out of scope: {FuncType}", funcType);
                 return new BadRequestObjectResult($"Your specified API type is out of scope[{funcType}].");
             }
-            logger.LogInformation("Query Parameter: /api/call-from-cs?{FuncType}", funcType);
+            string safeFuncTypeForLog = funcType.Replace("\r", string.Empty).Replace("\n", string.Empty);
+            logger.LogInformation("Query Parameter: /api/call-from-cs?{FuncType}", safeFuncTypeForLog);
 
             ResMsg resMsg = new ResMsg();
             try


### PR DESCRIPTION
Potential fix for [https://github.com/anishi1222/managed-identity-for-Azure-Functions-in-.NET/security/code-scanning/5](https://github.com/anishi1222/managed-identity-for-Azure-Functions-in-.NET/security/code-scanning/5)

Use explicit log sanitization for user-derived text before writing to logs.  
Best minimal fix: sanitize `funcType` by stripping CR/LF characters and log the sanitized value instead of the raw query value.

In `func-cs01/Func_cs01.cs`, update line 56 region:
- Create a local variable (e.g., `safeFuncTypeForLog`) from `funcType`.
- Remove `\r` and `\n` via `.Replace("\r", "").Replace("\n", "")`.
- Use `safeFuncTypeForLog` in `logger.LogInformation(...)`.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
