### PR TITLE
Potential fix for code scanning alert no. 4: Log entries created from user input

### DIFF
--- a/func-cs01/Func_cs01.cs
+++ b/func-cs01/Func_cs01.cs
@@ -40,6 +40,7 @@ namespace Func_cs01
         {
             logger.LogInformation("C# HTTP trigger function processed a request [call-from-cs].");
             string funcType = req.Query["type"].ToString().ToLowerInvariant();
+            string safeFuncTypeForLog = funcType.Replace("\r", string.Empty).Replace("\n", string.Empty);
             System.Console.WriteLine($"funcType {funcType}");
 
             // Check funcType
@@ -50,10 +51,9 @@ namespace Func_cs01
             }
             if (!TargetInfos.TryGetValue(funcType, out TargetInfo target))
             {
-                logger.LogError("Query Parameter is out of scope: {FuncType}", funcType);
+                logger.LogError("Query Parameter is out of scope: {FuncType}", safeFuncTypeForLog);
                 return new BadRequestObjectResult($"Your specified API type is out of scope[{funcType}].");
             }
-            string safeFuncTypeForLog = funcType.Replace("\r", string.Empty).Replace("\n", string.Empty);
             logger.LogInformation("Query Parameter: /api/call-from-cs?{FuncType}", safeFuncTypeForLog);
 
             ResMsg resMsg = new ResMsg();


### PR DESCRIPTION
Potential fix for [https://github.com/anishi1222/managed-identity-for-Azure-Functions-in-.NET/security/code-scanning/4](https://github.com/anishi1222/managed-identity-for-Azure-Functions-in-.NET/security/code-scanning/4)

Sanitize user input once (remove `\r` and `\n`) before *any* logging that includes it, and use that sanitized value in all log statements.  
Best minimal fix here: compute `safeFuncTypeForLog` immediately after reading `funcType`, then replace line 53 to log `safeFuncTypeForLog` instead of `funcType`. To keep behavior unchanged, do not alter validation logic (`TryGetValue`) or response messages; only change logging input.

In `func-cs01/Func_cs01.cs`:
- Move the existing sanitization assignment (currently line 56) to just after line 42.
- Update the out-of-scope error log (line 53) to use `safeFuncTypeForLog`.
- Remove the old duplicate declaration near line 56.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
